### PR TITLE
Fix version bump with a correct guard

### DIFF
--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -16,8 +16,16 @@ directory '/opt/dotnet' do
   recursive true
 end
 
-tar_extract node['dotnetcore']['package']['tar'] do
-  target_dir '/opt/dotnet'
+if node['dotnetcore']['package']['version']
+  creates_guard = "/opt/dotnet/shared/Microsoft.NETCore.App/#{node['dotnetcore']['package']['version']}"
+  tar_extract node['dotnetcore']['package']['tar'] do
+    target_dir '/opt/dotnet'
+    creates creates_guard
+  end
+else
+  tar_extract node['dotnetcore']['package']['tar'] do
+    target_dir '/opt/dotnet'
+  end
 end
 
 link '/usr/bin/dotnet' do

--- a/recipes/_tar_install.rb
+++ b/recipes/_tar_install.rb
@@ -16,16 +16,9 @@ directory '/opt/dotnet' do
   recursive true
 end
 
-if node['dotnetcore']['package']['version']
-  creates_guard = "/opt/dotnet/shared/Microsoft.NETCore.App/#{node['dotnetcore']['package']['version']}"
-  tar_extract node['dotnetcore']['package']['tar'] do
-    target_dir '/opt/dotnet'
-    creates creates_guard
-  end
-else
-  tar_extract node['dotnetcore']['package']['tar'] do
-    target_dir '/opt/dotnet'
-  end
+tar_extract node['dotnetcore']['package']['tar'] do
+  target_dir '/opt/dotnet'
+  creates "/opt/dotnet/shared/Microsoft.NETCore.App/#{node['dotnetcore']['package']['version']}" if node['dotnetcore']['package']['version']
 end
 
 link '/usr/bin/dotnet' do


### PR DESCRIPTION
This adds the possibility to specify dotnetcore version to add a guard with creates to force installation of a new version.
It was necessary in order to force installation even if the tar has already been downloaded because tar_extract triggers extract only after an actual download. If the installation failed for some reason, it was not re-downloaded the archive and thus not installed.